### PR TITLE
Migrate to TinyUSB native support

### DIFF
--- a/EZ_USB_MIDI_HOST.cpp
+++ b/EZ_USB_MIDI_HOST.cpp
@@ -1,8 +1,7 @@
-/**
- *
+/*
  * The MIT License (MIT)
  *
- * Copyright (c) 2023 rppicomidi
+ * Copyright (c) 2025 rppicomidi, DisasterAreaDesigns
  *
  * Permission is hereby granted, free of charge, to any person obtaining a copy
  * of this software and associated documentation files (the "Software"), to deal
@@ -23,53 +22,12 @@
  * THE SOFTWARE.
  */
 
-/**
- * @file EZ_USB_MIDI_HOST.cpp
- * This file contains the C callback functions for the usb_midi_host library.
- * These callbacks have to be defined here because the Arduino IDE will not
- * link these functions to the usb_midi_host library if they are defined in
- * the sketch directory. This adds a single function call overhead to the
- * callbacks over using the raw usb_midi_host library.
- */
-#include <cstdint>
+#include "EZ_USB_MIDI_HOST.h"
 
-static void* inst_ptr = nullptr; //!< a pointer to the instance of the EZ_USB_MIDI_HOST class that the application created
-/* The following are pointers to the callback functions implemented in the EZ_USB_MIDI_HOST class */
-static void (*mount_cb_fp)(uint8_t devAddr, uint8_t nInCables, uint16_t nOutCables, void* inst)=nullptr;
-static void (*umount_cb_fp)(uint8_t devAddr, void* inst)=nullptr;
-static void (*rx_cb_fp)(uint8_t devAddr, uint32_t numPackets, void* inst)=nullptr;
-
-/**
- * @brief Initialize the pointers to the callback functions. The EZ_USB_MIDI_HOST
- * class constructor should call this. Applications probably should not.
- */
-extern "C" void rppicomidi_ez_usb_midi_host_set_cbs(void (*mount_cb)(uint8_t devAddr, uint8_t nInCables, uint16_t nOutCables, void*),
-					 void (*umount_cb)(uint8_t devAddr, void*), void (*rx_cb)(uint8_t devAddr, uint32_t numPackets, void*),
-					 void* inst)
-{
-  mount_cb_fp = mount_cb;
-  umount_cb_fp = umount_cb;
-  rx_cb_fp = rx_cb;
-  inst_ptr = inst;
-}
-
-/* The following functions override the weak functions declared in the usb_midi_host library */
-
-extern "C" void tuh_midi_mount_cb(uint8_t devAddr, uint8_t inEP, uint8_t outEP, uint8_t nInCables, uint16_t nOutCables)
-{
-  (void)inEP;
-  (void)outEP;
-  mount_cb_fp(devAddr, nInCables, nOutCables, inst_ptr); 
-}
-
-extern "C" void tuh_midi_umount_cb(uint8_t devAddr, uint8_t unused)
-{
-  (void)unused;
-  umount_cb_fp(devAddr, inst_ptr);
-}
-
-extern "C" void tuh_midi_rx_cb(uint8_t devAddr, uint32_t numPackets)
-{
-  rx_cb_fp(devAddr, numPackets, inst_ptr);
-}
-
+// This file intentionally left mostly empty.
+// The TinyUSB callbacks (tuh_midi_mount_cb, tuh_midi_umount_cb, tuh_midi_rx_cb)
+// are defined by the RPPICOMIDI_EZ_USB_MIDI_HOST_INSTANCE macro in the user's sketch.
+// 
+// Previous versions of this library defined these callbacks here, but with the
+// migration to built-in TinyUSB MIDI host, they must be defined in the sketch
+// to properly link to the specific instance created by the macro.

--- a/README.md
+++ b/README.md
@@ -1,3 +1,5 @@
+WIP - updating the readme as I implement these changes
+
 # EZ_USB_MIDI_HOST
 This README file contains the design notes and limitations of the
 C++ library code that lets Arduino sketches and C/C++ programs
@@ -22,14 +24,11 @@ later. The previous versions used a different API.
 
 # Adding this library to your project
 ## C/C++ Programs
-First, you must install the [usb_midi_host](https://github.com/rppicomidi/usb_midi_host) library in your file
-system at the same directory level as this project. That is,
-if this library source is installed in directory `EZ_USB_MIDI_HOST`,
-then the directory of the usb_midi_host library must be
-`EZ_USB_MIDI_HOST/../usb_midi_host`. You must also make sure
-you have the pico-sdk installed correctly, that the TinyUSB library
+This updated version removes the dependency for the [usb_midi_host](https://github.com/rppicomidi/usb_midi_host) library. You must also make sure you have the pico-sdk installed correctly, that the TinyUSB library
 is up to date, and if your hardware requires it, the Pico_PIO_USB
-library is installed. See the Building C/C++ applications section
+library is installed. This has been tested with v0.5.3 of the Pico_PIO_USB library, later versions may have issues, see the info on its GitHub repo.
+
+See the Building C/C++ applications section
 of the usb_midi_host [README](https://github.com/rppicomidi/usb_midi_host/blob/main/README.md)
 for more information.
 Finally, you must install the [Arduino MIDI Library](https://github.com/FortySevenEffects/arduino_midi_library)
@@ -44,8 +43,7 @@ see the `EZ_USB_MIDI_HOST_PIO_example` for other details.
 
 ## Arduino
 First, use the Library Manager to install this library and install all of
-its dependencies (Adafruit TinyUSB Arduino Library, the Arduino MIDI Library,
-the usb_midi_host Library). Next, if your hardware requires it, install the
+its dependencies (Adafruit TinyUSB Arduino Library and the Arduino MIDI Library.  Next, if your hardware requires it, install the
 Pico_PIO_USB library.
 
 Adding `#include "EZ_USB_MIDI_HOST.h"` to your sketch should be sufficient
@@ -53,6 +51,8 @@ to integrate your Arduino sketch with this library and all of its dependencies.
 If you are using the Pico PIO USB Library to implement the host, you must
 also add `#include "pio_usb.h"` for `#include "EZ_USB_MIDI_HOST.h"`.
 See the `EZ_USB_MIDI_HOST_PIO_example` for other details.
+
+We have found that MIDI.h should be included before EZ_USB_MIDI_HOST to prevent errors during compilation.  If you are using TinyUSB for a dual-role device (for example USB MIDI and USB Host, or for debugging) it should be included *after* EZ_USB_MIDI_HOST.
 
 # EZ_USB_MIDI_HOST Library Design
 The Arduino MIDI Library has a Transport
@@ -72,14 +72,14 @@ following software components layered as follows:
 |              | EZ_USB_MIDI_HOST           |
 |              | EZ_USB_MIDI_HOST_Device    |
 | MIDI Library | EZ_USB_MIDI_HOST_Transport |
-| TinyUSB      | usb_midi_host_app_driver   |
+| TinyUSB      |   	|
 
 The application interacts with a single `EZ_USB_MIDI_HOST` object.
 The `EZ_USB_MIDI_HOST` object has as many `EZ_USB_MIDI_HOST_Device`
 objects as there are hub ports. Each device has a configurable
 number of `MIDI Library` bidirectional streams; each stream has
-a `EZ_USB_MIDI_HOST_Transport` interface. Each`EZ_USB_MIDI_HOST_Transport` object interacts with the
-`TinyUSB` library supplemented by the `usb_midi_host_app_driver`.
+a `EZ_USB_MIDI_HOST_Transport` interface. Each`EZ_USB_MIDI_HOST_Transport` object interacts directly with the
+`TinyUSB` library.
 
 # Writing Applications
 To create an instance of the EZ_USB_MIDI_HOST class for your

--- a/library.properties
+++ b/library.properties
@@ -1,8 +1,8 @@
 name=EZ_USB_MIDI_HOST
-version=2.2.0
+version=2.2.1
 author=rppicomidi
 maintainer=rppicomidi
-sentence=Arduino MIDI Library wrapper for usb_midi_host library
+sentence=Arduino MIDI Library wrapper for TinyUSB library
 paragraph=Works for Arduino and C++; uses same API as Serial MIDI and other Transports
 category=Communication
 url=https://github.com/rppicomidi/EZ_USB_MIDI_HOST


### PR DESCRIPTION
Initial commit to add TinyUSB native support.

Important note:  tested on RP2040 hardware.  Adafruit_TinyUSB 3.7.3 does not have USB Host MIDI support enabled, so you must add the following lines to /src/arduino/ports/rp2040/tusb_config_rp2040.h:

// enable MIDI Host
#define CFG_TUH_MIDI (CFG_TUH_DEVICE_MAX)

